### PR TITLE
Refactor/tools new descriptions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,12 @@
+# [0.4.0](https://github.com/Jeremias-A-Queiroz/emacs-gptel-slim-tools/compare/v0.3.0...v0.4.0) (2026-04-13)
+
+
+### Features
+
+* Adiciona injeção de contexto para nomes de cache ([32482a1](https://github.com/Jeremias-A-Queiroz/emacs-gptel-slim-tools/commit/32482a17d394683dac87a0469f2a7ffebcc926b6))
+
+
+
 # [0.3.0](https://github.com/Jeremias-A-Queiroz/emacs-gptel-slim-tools/compare/v0.2.1...v0.3.0) (2026-04-05)
 
 

--- a/docs/ROADMAP.org
+++ b/docs/ROADMAP.org
@@ -1,0 +1,104 @@
+#+TITLE: Roadmap de Evolução: gptel-slim-tools
+#+AUTHOR: Jeremias & LLM
+#+DESCRIPTION: Orquestração do desenvolvimento das novas features Agentic/Suckless
+#+STARTUP: showeverything
+
+* Visão Geral e Filosofia
+Este documento serve como o mapa arquitetural e o ambiente de desenvolvimento interativo para a evolução do pacote =gptel-slim-tools=.
+Aproveitando o recurso ~gptel-org-branching-context~ e a propriedade ~GPTEL_TOPIC~, cada subtópico abaixo funciona como uma "sala de chat" isolada. Quando você invocar o gptel dentro de um dos tópicos, o LLM terá o contexto focado apenas naquela feature, utilizando o ~GPTEL_SYSTEM~ customizado para a tarefa.
+
+A filosofia central permanece: *KISS, Suckless, sem RAG pesado, sem telemetria. Apenas Emacs nativo, Git, LSP e texto puro.*
+
+---
+
+* Feature 1: Edição Inline com Ediff (apply_patch_to_buffer)
+:PROPERTIES:
+:GPTEL_TOPIC: ediff_workflow
+:GPTEL_SYSTEM: Você é um expert em Emacs Lisp. Seu objetivo atual é implementar a tool 'apply_patch_to_buffer' para o gptel-slim-tools. A tool deve receber um diff unificado, aplicá-mo em um buffer temporário e invocar o 'ediff-buffers' nativo para que o usuário faça o merge visual. Mantenha o código limpo e sem dependências externas.
+:END:
+
+** Conceito (Do Cache)
+Ideia: Criar uma tool =apply_patch_to_buffer=. O LLM gera um unified diff (ou comandos ed). O Emacs intercepta, aplica em um buffer temporário e abre o =ediff= nativo para o usuário fazer o merge visual (aceitar/rejeitar). Resolve o problema de edição inline sem UIs complexas.
+
+** Plano de Implementação
+1. Criar a função Elisp =gptel-slim-apply-patch (buffer-name patch-string)=.
+2. A função deve:
+   - Clonar o buffer alvo para um buffer temporário (ex: =*gptel-patch-target*=).
+   - Aplicar o patch no buffer temporário usando =patch-buffer= ou utilitários nativos de diff.
+   - Chamar =ediff-buffers= entre o buffer original e o buffer temporário.
+   - Adicionar um hook no =ediff-quit-hook= para limpar o buffer temporário após a decisão do usuário.
+3. Registrar a tool via =gptel-make-tool=.
+
+** Espaço para Código e Interação
+(Posicione o cursor aqui e chame o gptel para começarmos a codificar esta feature)
+
+---
+
+* Feature 2: Resolução do Ponto Cego 1 (Estado Original via Git)
+:PROPERTIES:
+:GPTEL_TOPIC: git_state_tools
+:GPTEL_SYSTEM: Você é um expert em Emacs Lisp e Git. Seu objetivo é criar tools para o gptel-slim-tools que permitam ao LLM ler o estado original de arquivos antes das edições do usuário, usando o VC nativo do Emacs ou chamadas diretas ao Git.
+:END:
+
+** Conceito (Do Cache)
+Ideia: Resolver o problema de 'edição em andamento' (onde o LLM só vê o código quebrado no buffer) usando o Git. Criar tools como =get_buffer_diff= (git diff -U3) e =read_tag_from_head= (git show HEAD:arquivo). Isso permite ao LLM entender a intenção original do usuário comparando o estado limpo com o sujo, gastando poucos tokens.
+
+** Plano de Implementação
+1. *Tool 1: =get_buffer_diff=*
+   - Função: =gptel-slim-git-diff (buffer-name)=
+   - Lógica: Usar =vc-working-revision= e =vc-diff= programaticamente, ou um simples =shell-command-to-string= executando =git diff -U3 <arquivo>=.
+2. *Tool 2: =read_tag_from_head=*
+   - Função: =gptel-slim-git-show-tag (tag-name file-path)=
+   - Lógica: Fazer um =git show HEAD:file-path= em um buffer temporário invisível, e reutilizar a lógica atual do =gptel-thin-tags= para extrair apenas a função/tag desejada desse buffer histórico.
+
+** Espaço para Código e Interação
+(Posicione o cursor aqui e chame o gptel para começarmos a codificar esta feature)
+
+---
+
+* Feature 3: O "Project Ledger" (.llm-doc.json) e Motor de Consulta
+:PROPERTIES:
+:GPTEL_TOPIC: project_ledger
+:GPTEL_SYSTEM: Você é um Arquiteto de Software e expert em Emacs Lisp. Seu objetivo é projetar a geração e consulta do arquivo '.llm-doc.json'. Foco em usar a API nativa de JSON do Emacs 28+ (json-parse-string) e integração com Eglot/Tree-sitter para extrair referências cruzadas.
+:END:
+
+** Conceito (Do Cache)
+- *Geração:* Criar um =.llm-doc.json= na raiz do projeto, gerado via LSP (Eglot) + LLM, e atualizado via Git hooks (diffs).
+- *Consulta:* Usar o motor JSON nativo do Emacs para extrair blocos específicos. Se as chaves do JSON mapearem exatamente os nomes do arquivo TAGS, a tool =query_project_doc= pode retornar apenas o nó relevante (ex: a função e suas referências cruzadas) com custo zero de parsing para o LLM.
+
+** Plano de Implementação
+1. *O Gerador Inicial (=gptel-slim-init-doc=):*
+   - Script interativo que varre o projeto.
+   - Tenta usar =eglot= (se disponível) para extrair =textDocument/references=.
+   - Fallback para Tree-sitter.
+   - Estrutura o JSON com as chaves exatas do arquivo =TAGS=.
+2. *O Motor de Consulta (Tool =query_project_doc=):*
+   - Função: =gptel-slim-query-doc (tag-name)=
+   - Lógica: Ler =.llm-doc.json=, fazer o parse com =json-parse-file= (retornando hash-table). Executar =(gethash tag-name (gethash "tags" json-data))= e serializar a resposta de volta para string.
+3. *O Hook de Manutenção:*
+   - Criar um script para =post-commit= que lê o diff, envia para o LLM gerar o summary em background, e atualiza o JSON.
+
+** Espaço para Código e Interação
+(Posicione o cursor aqui e chame o gptel para começarmos a codificar esta feature)
+
+---
+
+* Feature 4: Injeção Automática de Diagnósticos (Flymake/Eglot)
+:PROPERTIES:
+:GPTEL_TOPIC: flymake_injection
+:GPTEL_SYSTEM: Você é um expert em Emacs Lisp. Seu objetivo é criar um advice ou hook no gptel para capturar os erros do Flymake na região selecionada pelo usuário e injetá-los no prompt enviado ao LLM.
+:END:
+
+** Conceito (Do Cache)
+Ideia: Enriquecer o contexto do LLM com diagnósticos em tempo real do Flymake/Eglot. Quando o usuário pede ajuda em uma região, o Emacs extrai automaticamente os erros/avisos (=flymake-diagnostics=) daquele trecho e injeta no prompt. O LLM vê exatamente o que o compilador/LSP está reclamando.
+
+** Plano de Implementação (Abordagem 1 - Automática)
+1. Criar a função de extração: =gptel-slim-get-flymake-errors (beg end)=.
+   - Iterar sobre =(flymake-diagnostics beg end)=.
+   - Formatar como texto puro: ="- [error] Line X: Mensagem"=.
+2. Integração com o gptel:
+   - Investigar a melhor forma de injetar isso. Como o =gptel-org.el= usa =gptel--send-with-props= (um advice em =gptel-send=), podemos criar um advice similar (ex: =:before= ou =:around=) no =gptel-send= ou =gptel-request= que verifica se há região ativa e se há erros do flymake nela.
+   - Se houver, anexa a string formatada ao final do prompt do usuário antes de enviar para a API.
+
+** Espaço para Código e Interação
+(Posicione o cursor aqui e chame o gptel para começarmos a codificar esta feature)

--- a/docs/ROADMAP.org
+++ b/docs/ROADMAP.org
@@ -1,98 +1,222 @@
 #+TITLE: Roadmap de Evolução: gptel-slim-tools
-#+AUTHOR: Jeremias & LLM
+#+AUTHOR: Jeremias
 #+DESCRIPTION: Orquestração do desenvolvimento das novas features Agentic/Suckless
 #+STARTUP: showeverything
 
+* Orientações
+Aproveitando o recurso ~gptel-org-branching-context~ e a propriedade
+~GPTEL_TOPIC~, cada subtópico abaixo funciona como uma "sala de chat"
+isolada. Quando você invocar o gptel dentro de um dos tópicos, o LLM
+terá o contexto focado apenas naquela feature, utilizando o
+~GPTEL_SYSTEM~ customizado para a tarefa.
+
+Exemplo de Drawer de isolamento de tópico:
+:PROPERTIES:
+:GPTEL_TOPIC: nomedotopico
+:END:
+
 * Visão Geral e Filosofia
 Este documento serve como o mapa arquitetural e o ambiente de desenvolvimento interativo para a evolução do pacote =gptel-slim-tools=.
-Aproveitando o recurso ~gptel-org-branching-context~ e a propriedade ~GPTEL_TOPIC~, cada subtópico abaixo funciona como uma "sala de chat" isolada. Quando você invocar o gptel dentro de um dos tópicos, o LLM terá o contexto focado apenas naquela feature, utilizando o ~GPTEL_SYSTEM~ customizado para a tarefa.
 
 A filosofia central permanece: *KISS, Suckless, sem RAG pesado, sem telemetria. Apenas Emacs nativo, Git, LSP e texto puro.*
 
----
-
-* Feature 1: Edição Inline com Ediff (apply_patch_to_buffer)
-:PROPERTIES:
-:GPTEL_TOPIC: ediff_workflow
-:GPTEL_SYSTEM: Você é um expert em Emacs Lisp. Seu objetivo atual é implementar a tool 'apply_patch_to_buffer' para o gptel-slim-tools. A tool deve receber um diff unificado, aplicá-mo em um buffer temporário e invocar o 'ediff-buffers' nativo para que o usuário faça o merge visual. Mantenha o código limpo e sem dependências externas.
-:END:
-
-** Conceito (Do Cache)
-Ideia: Criar uma tool =apply_patch_to_buffer=. O LLM gera um unified diff (ou comandos ed). O Emacs intercepta, aplica em um buffer temporário e abre o =ediff= nativo para o usuário fazer o merge visual (aceitar/rejeitar). Resolve o problema de edição inline sem UIs complexas.
-
-** Plano de Implementação
-1. Criar a função Elisp =gptel-slim-apply-patch (buffer-name patch-string)=.
-2. A função deve:
-   - Clonar o buffer alvo para um buffer temporário (ex: =*gptel-patch-target*=).
-   - Aplicar o patch no buffer temporário usando =patch-buffer= ou utilitários nativos de diff.
-   - Chamar =ediff-buffers= entre o buffer original e o buffer temporário.
-   - Adicionar um hook no =ediff-quit-hook= para limpar o buffer temporário após a decisão do usuário.
-3. Registrar a tool via =gptel-make-tool=.
-
-** Espaço para Código e Interação
-(Posicione o cursor aqui e chame o gptel para começarmos a codificar esta feature)
+- O Workflow Agêntico (Macro vs Micro)
+  Para que o LLM atue como um agente autônomo eficiente, ele deve buscar o contexto mais barato e determinístico primeiro, antes de gastar tokens gerando respostas (orquestração inteligente). A hierarquia ideal de investigação é:
+  1. *Big Picture (Macro):* Consultar =.llm-doc.json= via =query_project_doc= para entender a arquitetura e dependências.
+  2. *Definições Estáveis:* Usar =investigate_code_tag= (TAGS) para ler o código de dependências externas do projeto.
+  3. *Estado Atual (Micro):* Usar =list_buffer_tags= e =read_tag_source= para mapear e ler o código em edição ativa (não salvo).
+  4. *Histórico/Intenção:* Usar =read_buffer_diff= e =read_tag_from_head= para entender as mudanças recentes e a intenção original.
+  5. *Memória:* Usar =llm_cache_set= continuamente para reter descobertas importantes como uma "lousa" de trabalho.
 
 ---
 
-* Feature 2: Resolução do Ponto Cego 1 (Estado Original via Git)
+** Feature 1: O "Project Ledger" (.llm-doc.json) e Motor de Consulta
+
+*Conceito*
+- *Geração:* Criar um =.llm-doc.json= na raiz dos projetos versionados, gerado via LSP (Eglot) + LLM, e atualizado via Git hooks (diffs).
+- *Consulta:* Usar o motor JSON nativo do Emacs para extrair blocos específicos. Se as chaves do JSON mapearem exatamente os nomes do arquivo TAGS, a tool =query_project_doc= pode retornar apenas o nó relevante (ex: a função e suas referências cruzadas) com custo zero de parsing para o LLM.
+
+*Plano de Implementação* [1/4]
+- [X]  *Definição do Schema*
+  - Definição de um schema abrangente e enxuto para a doc de um projeto;
+- [ ]  *O Gerador Inicial (=gptel-slim-init-doc=):*
+  - Script interativo que varre o projeto.
+  - Tenta usar =eglot= (se disponível) para extrair =textDocument/references=.
+  - Fallback para Tree-sitter.
+  - Estrutura o JSON com as chaves exatas do arquivo =TAGS=.
+- [ ]  *O Motor de Consulta (Tool =query_project_doc=):*
+  - Função: =gptel-slim-query-doc (tag-name)=
+  - Lógica: Ler =.llm-doc.json=, fazer o parse com =json-parse-file= (retornando hash-table). Executar =(gethash tag-name (gethash "tags" json-data))= e serializar a resposta de volta para string.
+- [ ]  *O Hook de Manutenção:*
+  - Criar um script para =post-commit= que lê o diff, envia para o LLM gerar o summary em background, e atualiza o JSON.
+
+---
+*SCHEMA*
+
+#+caption: Schema Completo do =.llm-doc.json=
+#+begin_src json
+{
+  "project_name": "string",
+  "last_commit_hash": "string",
+  "commit_timestamp": "string",
+  "external_dependencies": [
+    {
+      "name": "string",
+      "version": "string | null",
+      "description": "string | null",
+      "type": "string | null"
+    }
+  ],
+  "tags": [
+    {
+      "tag_name": "string",
+      "type": "string",
+      "origin_file": "string",
+      "summary": "string",
+      "cross_references": [
+        "string"
+      ],
+      "signature": "string | null",
+      "scope": "string | null",
+      "data_type": "string | null"
+    }
+  ]
+}
+#+end_src
+
+*Documentação Detalhada dos Campos*
+
+*/Campos de Nível Superior/*
+
+1.  *=project_name=*
+    *   *Tipo:* =string=
+    *   *Obrigatório:* Sim
+    *   *Descrição:* O nome do projeto. Deve ser um identificador claro e conciso.
+    *   *Exemplo:* ="my-awesome-project"=
+
+2.  *=last_commit_hash=*
+    *   *Tipo:* =string=
+    *   *Obrigatório:* Sim
+    *   *Descrição:* O hash completo do último commit no histórico do Git. Usado para rastrear a versão do código à qual este documento de documentação se refere.
+    *   *Exemplo:* ="a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6e7f8a9b0"=
+
+3.  *=commit_timestamp=*
+    *   *Tipo:* =string=
+    *   *Obrigatório:* Sim
+    *   *Descrição:* O timestamp (data e hora) do último commit, geralmente no formato ISO 8601 ou similar. Indica quando as informações foram geradas ou atualizadas pela última vez.
+    *   *Exemplo:* ="2023-10-27T10:30:00Z"=
+
+4.  *=external_dependencies=*
+    *   *Tipo:* =array= de objetos (={ name: string, version: string | null, description: string | null, type: string | null }=)
+    *   *Obrigatório:* Não (pode ser um array vazio =[]=)
+    *   *Descrição:* Uma lista de todas as bibliotecas e dependências externas que o projeto utiliza. Cada item na lista descreve uma dependência.
+    *   *Campos do Objeto de Dependência:*
+        *   *=name=*
+            *   *Tipo:* =string=
+            *   *Obrigatório:* Sim
+            *   *Descrição:* O nome da biblioteca externa (ex: ="react"=, ="lodash"=, ="requests"=).
+            *   *Exemplo:* ="lodash"=
+        *   *=version=*
+            *   *Tipo:* =string | null=
+            *   *Obrigatório:* Não
+            *   *Descrição:* A versão específica da biblioteca sendo utilizada. Pode ser =null= se a versão não for estritamente definida ou gerenciada (ex: dependências em modo "latest" ou não versionadas).
+            *   *Exemplo:* ="4.17.21"=, =null=
+        *   *=description=*
+            *   *Tipo:* =string | null=
+            *   *Obrigatório:* Não
+            *   *Descrição:* Uma breve descrição do propósito ou funcionalidade da biblioteca externa. Idealmente, gerada pela LLM ou extraída de metadados.
+            *   *Exemplo:* ="Utility library delivering consistency, customization, performance, and more."=, =null=
+        *   *=type=*
+            *   *Tipo:* =string | null=
+            *   *Obrigatório:* Não
+            *   *Descrição:* O tipo de dependência (ex: ="npm"=, ="pip"=, ="maven"=, ="gem"=, ="system"=). Ajuda a contextualizar como a dependência é gerenciada.
+            *   *Exemplo:* ="npm"=, ="pip"=, =null=
+
+/Campo =tags=/
+
+-   *Tipo:* =array= de objetos (={ tag_name: string, type: string, origin_file: string, summary: string, cross_references: string[], signature?: string | null, scope?: string | null, data_type?: string | null }=)
+-   *Obrigatório:* Não (pode ser um array vazio =[]=)
+-   *Descrição:* Uma lista de todas as "tags" ou entidades significativas dentro do projeto (funções, variáveis, classes, etc.). Cada objeto representa uma tag.
+
+-   *Campos do Objeto de Tag:*
+    *   *=tag_name=*
+        *   *Tipo:* =string=
+        *   *Obrigatório:* Sim
+        *   *Descrição:* O nome da entidade (função, variável, classe, etc.). Deve ser o identificador exato usado no código.
+        *   *Exemplo:* ="calculate_total_price"=, ="user_count"=
+    *   *=type=*
+        *   *Tipo:* =string=
+        *   *Obrigatório:* Sim
+        *   *Descrição:* O tipo da entidade. Valores comuns incluem: ="function"=, ="variable"=, ="class"=, ="method"=, ="interface"=, ="enum"=, ="struct"=.
+        *   *Exemplo:* ="function"=
+    *   *=origin_file=*
+        *   *Tipo:* =string=
+        *   *Obrigatório:* Sim
+        *   *Descrição:* O caminho relativo do arquivo onde esta tag está definida.
+        *   *Exemplo:* ="src/utils/math.js"=, ="lib/user_management.py"=
+    *   *=summary=*
+        *   *Tipo:* =string=
+        *   *Obrigatório:* Sim
+        *   *Descrição:* Um resumo conciso gerado pela LLM sobre o propósito e a funcionalidade desta tag. Baseado em análise de código, comentários e/ou documentação existente.
+        *   *Exemplo:* ="Calculates the final price including taxes and discounts."=
+    *   *=cross_references=*
+        *   *Tipo:* =array= de =string=
+        *   *Obrigatório:* Sim (pode ser um array vazio =[]=)
+        *   *Descrição:* Uma lista de =tag_name=s de outras entidades (dentro ou fora deste projeto, se conhecidas) que referenciam ou são referenciadas por esta tag. Ajuda a construir o grafo de dependências.
+        *   *Exemplo:* =["apply_discount", "get_tax_rate"]=
+    *   *=signature=*
+        *   *Tipo:* =string | null=
+        *   *Obrigatório:* Não
+        *   *Descrição:* (Opcional) A assinatura da função ou método, incluindo parâmetros e tipo de retorno. Útil para linguagens com tipagem estática ou para clareza.
+        *   *Exemplo:* ="(price: number, discount: number = 0): number"=, ="(user_id: int) -> User"=, =null=
+    *   *=scope=*
+        *   *Tipo:* =string | null=
+        *   *Obrigatório:* Não
+        *   *Descrição:* (Opcional) O escopo em que a tag está definida (ex: ="global"=, ="local"=, ="private"=, ="public"=, ="protected"=).
+        *   *Exemplo:* ="public"=, ="private"=, =null=
+    *   *=data_type=*
+        *   *Tipo:* =string | null=
+        *   *Obrigatório:* Não
+        *   *Descrição:* (Opcional) Para variáveis ou campos, o tipo de dado que ela armazena (ex: ="int"=, ="string"=, ="boolean"=, ="list[str]"=, ="User"=).
+        *   *Exemplo:* ="int"=, ="string"=, ="list[str]"=, =null=
+
+
+---
+
+*** O Gerador inicial
+
+*** O motor de consulta
+
+*** Hook de manutenção
+
+** Feature 2: Original via Git
 :PROPERTIES:
 :GPTEL_TOPIC: git_state_tools
-:GPTEL_SYSTEM: Você é um expert em Emacs Lisp e Git. Seu objetivo é criar tools para o gptel-slim-tools que permitam ao LLM ler o estado original de arquivos antes das edições do usuário, usando o VC nativo do Emacs ou chamadas diretas ao Git.
 :END:
 
-** Conceito (Do Cache)
-Ideia: Resolver o problema de 'edição em andamento' (onde o LLM só vê o código quebrado no buffer) usando o Git. Criar tools como =get_buffer_diff= (git diff -U3) e =read_tag_from_head= (git show HEAD:arquivo). Isso permite ao LLM entender a intenção original do usuário comparando o estado limpo com o sujo, gastando poucos tokens.
+*** Conceito
+Ideia: Resolver o problema de 'edição em andamento' (onde o LLM só vê o código quebrado no buffer) usando o Git. Criar tools para comparar o estado limpo com o sujo, gastando poucos tokens. Isso permite ao LLM entender a intenção original do usuário comparando o estado limpo com o sujo.
 
-** Plano de Implementação
-1. *Tool 1: =get_buffer_diff=*
+*** Plano de Implementação
+1. *Tool 1: =read_buffer_diff=*
    - Função: =gptel-slim-git-diff (buffer-name)=
    - Lógica: Usar =vc-working-revision= e =vc-diff= programaticamente, ou um simples =shell-command-to-string= executando =git diff -U3 <arquivo>=.
 2. *Tool 2: =read_tag_from_head=*
    - Função: =gptel-slim-git-show-tag (tag-name file-path)=
    - Lógica: Fazer um =git show HEAD:file-path= em um buffer temporário invisível, e reutilizar a lógica atual do =gptel-thin-tags= para extrair apenas a função/tag desejada desse buffer histórico.
 
-** Espaço para Código e Interação
-(Posicione o cursor aqui e chame o gptel para começarmos a codificar esta feature)
-
 ---
 
-* Feature 3: O "Project Ledger" (.llm-doc.json) e Motor de Consulta
-:PROPERTIES:
-:GPTEL_TOPIC: project_ledger
-:GPTEL_SYSTEM: Você é um Arquiteto de Software e expert em Emacs Lisp. Seu objetivo é projetar a geração e consulta do arquivo '.llm-doc.json'. Foco em usar a API nativa de JSON do Emacs 28+ (json-parse-string) e integração com Eglot/Tree-sitter para extrair referências cruzadas.
-:END:
-
-** Conceito (Do Cache)
-- *Geração:* Criar um =.llm-doc.json= na raiz do projeto, gerado via LSP (Eglot) + LLM, e atualizado via Git hooks (diffs).
-- *Consulta:* Usar o motor JSON nativo do Emacs para extrair blocos específicos. Se as chaves do JSON mapearem exatamente os nomes do arquivo TAGS, a tool =query_project_doc= pode retornar apenas o nó relevante (ex: a função e suas referências cruzadas) com custo zero de parsing para o LLM.
-
-** Plano de Implementação
-1. *O Gerador Inicial (=gptel-slim-init-doc=):*
-   - Script interativo que varre o projeto.
-   - Tenta usar =eglot= (se disponível) para extrair =textDocument/references=.
-   - Fallback para Tree-sitter.
-   - Estrutura o JSON com as chaves exatas do arquivo =TAGS=.
-2. *O Motor de Consulta (Tool =query_project_doc=):*
-   - Função: =gptel-slim-query-doc (tag-name)=
-   - Lógica: Ler =.llm-doc.json=, fazer o parse com =json-parse-file= (retornando hash-table). Executar =(gethash tag-name (gethash "tags" json-data))= e serializar a resposta de volta para string.
-3. *O Hook de Manutenção:*
-   - Criar um script para =post-commit= que lê o diff, envia para o LLM gerar o summary em background, e atualiza o JSON.
-
-** Espaço para Código e Interação
-(Posicione o cursor aqui e chame o gptel para começarmos a codificar esta feature)
-
----
-
-* Feature 4: Injeção Automática de Diagnósticos (Flymake/Eglot)
+** Feature 3: Injeção Automática de Diagnósticos (Flymake/Eglot)
 :PROPERTIES:
 :GPTEL_TOPIC: flymake_injection
-:GPTEL_SYSTEM: Você é um expert em Emacs Lisp. Seu objetivo é criar um advice ou hook no gptel para capturar os erros do Flymake na região selecionada pelo usuário e injetá-los no prompt enviado ao LLM.
 :END:
 
-** Conceito (Do Cache)
+*** Conceito
+
 Ideia: Enriquecer o contexto do LLM com diagnósticos em tempo real do Flymake/Eglot. Quando o usuário pede ajuda em uma região, o Emacs extrai automaticamente os erros/avisos (=flymake-diagnostics=) daquele trecho e injeta no prompt. O LLM vê exatamente o que o compilador/LSP está reclamando.
 
-** Plano de Implementação (Abordagem 1 - Automática)
+*** Plano de Implementação (Abordagem 1 - Automática)
 1. Criar a função de extração: =gptel-slim-get-flymake-errors (beg end)=.
    - Iterar sobre =(flymake-diagnostics beg end)=.
    - Formatar como texto puro: ="- [error] Line X: Mensagem"=.
@@ -100,5 +224,24 @@ Ideia: Enriquecer o contexto do LLM com diagnósticos em tempo real do Flymake/E
    - Investigar a melhor forma de injetar isso. Como o =gptel-org.el= usa =gptel--send-with-props= (um advice em =gptel-send=), podemos criar um advice similar (ex: =:before= ou =:around=) no =gptel-send= ou =gptel-request= que verifica se há região ativa e se há erros do flymake nela.
    - Se houver, anexa a string formatada ao final do prompt do usuário antes de enviar para a API.
 
-** Espaço para Código e Interação
-(Posicione o cursor aqui e chame o gptel para começarmos a codificar esta feature)
+---
+
+** Feature 4: Orquestração, System Prompts e Gatilhos Condicionais
+:PROPERTIES:
+:GPTEL_TOPIC: orchestration
+:END:
+
+*** Conceito
+Como as ferramentas são modulares e independentes (KISS/Suckless), o
+LLM precisa de dicas de como combiná-las dinamicamente. Faremos isso
+através de um System Prompt mestre e "Gatilhos Condicionais" embutidos
+nas descrições das tools, permitindo que elas funcionem perfeitamente
+sozinhas, mas sugiram sinergias quando outras tools estiverem ativas. 
+
+*** Plano de Implementação
+1. [ ] *Refatoração das Descriptions (Gatilhos Condicionais):*
+   - Atualizar as descrições das tools atuais (=investigate_code_tag=, =read_tag_source=, =llm_cache_set=, etc.).
+   - *Regra:* 90% da descrição foca na utilidade isolada, 10% no final sugere sinergia.
+   - *Exemplo para =read_tag_source=:* "... Extrai o código fonte exato. *Sinergia:* Se precisar entender a arquitetura antes, use 'query_project_doc' (se ativa). Para salvar este código para depois, use 'llm_cache_set'."
+2. [ ] *Criação do System Prompt Mestre:*
+   - Desenhar a persona do Agente Investigativo que prioriza a economia de tokens e a busca determinística (JSON > TAGS > Buffer > Diff).

--- a/docs/ROADMAP.org
+++ b/docs/ROADMAP.org
@@ -295,7 +295,8 @@ Este workflow garante que o `gptel-slim-init-doc` seja um gerador abrangente, qu
       determinística, o único trabalho do LLM deve ser chamar
       'llm_cache_clean' e a tool deve cuidar do restante.
 
-*** Gestão dos nomes de cache
+*** DONE Gestão dos nomes de cache
+CLOSED: [2026-04-13 Mon 14:37]
 
 /Proposta Técnica: Injeção Dinâmica de Contexto de Cache no =gptel=/
 
@@ -419,164 +420,6 @@ próxima injeção. Não há necessidade de mecanismos adicionais de
 sincronização ou limpeza de estado para a string injetada, pois ela é
 efêmera e gerada sob demanda. 
 
-**** Implementação
-
-Seguindo todas as boas práticas de programação elisp e todo o
-direcionamento técnico exposto acima precisamos criar a função
-=gptel-slim-inject-cache-names= e o hook para
-=gptel-prompt-transform-functions= 
-
-Para tanto segue código fonte das tools de cache:
-
-[[~/src/emacs-gptel-slim-tools/gptel-llm-cache.el]]
-
-
-Também segue o arquivo TAGS 
-
-[[~/.emacs.d/elpa/gptel-20260408.557/TAGS]]
-
-Que deve ser usado com a tool =investigate_code_tags= para gerar
-contexto e assim podermos executar essa implementação dentro das
-melhores práticas possíveis.
-
-
-
-
-#+begin_tool (investigate_code_tag :tags_file "~/.emacs.d/elpa/gptel-20260408.557/TAGS" :tag_name "gptel-prompt-transform-functions")
-(:name "investigate_code_tag" :args (:tags_file "~/.emacs.d/elpa/gptel-20260408.557/TAGS" :tag_name "gptel-prompt-transform-functions"))
-
-(defcustom gptel-prompt-transform-functions
-  '(gptel--transform-apply-preset gptel--transform-add-context)
-  "Handlers to augment or transform a query before sending it.
-
-This hook is called in a temporary buffer containing the text to
-be sent, with the cursor at the end of the prompt.  You can use
-it to modify the buffer or buffer-local variables as required.
-
-Since these functions modify the prompt construction buffer, the order
-in which they run is significant!  In particular, you may want to add
-your function before (the default) or after
-`gptel--transform-add-context', which adds gptel's context (other
-buffers, files etc) to this buffer.
-
-Example: A typical use case might be to search for occurrences of $(cmd)
-and replace it with the output of the shell command cmd, making it easy
-to send the output of shell commands to the LLM.
-
-Transform functions can be synchronous or asynchronous.
-
-Synchronous hook functions must accept zero or one argument: the INFO
-plist for the current request.
-
-Asynchronous hook functions must accept two arguments: a callback to
-call after the transformation is complete, and the INFO plist for the
-current request.
-
-Note that while this set of handlers can certainly be set with a global
-value to be applied to all queries in all buffers, it meant to be set
-locally for a specific buffer, or chat topic, or only the context of a
-certain task."
-  :type 'hook)
-
-
-#+end_tool
-#+begin_src elisp
-;;; gptel-llm-cache.el --- LLM-managed ephemeral session cache -*- lexical-binding: t; -*-
-
-(require 'gptel)
-
-(defvar gptel-llm-session-cache (make-hash-table :test 'eq)
-  "Hash table to store LLM-managed session cache data.
-Keys are symbols representing cache names, values are arbitrary Elisp data.
-This cache is ephemeral and cleared on Emacs restart.")
-
-(defun gptel-llm-cache-set (cache-name-string elisp-data-string)
-  "Sets or updates an Elisp data object in the LLM's in-memory session cache."
-  (let* ((cache-symbol (intern cache-name-string))
-         (data (read-from-string elisp-data-string)))
-    (puthash cache-symbol data gptel-llm-session-cache)
-    `((status . "success")
-      (cache_name . ,cache-name-string)
-      (data . ,(prin1-to-string data)))))
-
-(defun gptel-llm-cache-get (cache-name-string)
-  "Retrieves an Elisp data object from the LLM's in-memory session cache."
-  (let* ((cache-symbol (intern cache-name-string))
-         (data (gethash cache-symbol gptel-llm-session-cache)))
-    (if data
-        `((status . "success")
-          (cache_name . ,cache-name-string)
-          (data . ,(prin1-to-string data)))
-      `((status . "error")
-        (message . ,(format "LLM cache '%s' not found." cache-name-string))))))
-
-(defun gptel-llm-cache-list-names ()
-  "Lists the string names of all Elisp data objects currently stored.
-Used internally for context injection."
-  (let (names)
-    (maphash (lambda (key _value) (push (symbol-name key) names)) gptel-llm-session-cache)
-    `((status . "success")
-      (names . ,(vconcat (nreverse names))))))
-
-(defun gptel-llm-cache-clear (&optional cache-name-string)
-  "Clears a specific Elisp data object from the LLM's in-memory session cache."
-  (if cache-name-string
-      (if (gethash (intern cache-name-string) gptel-llm-session-cache)
-          (progn
-            (remhash (intern cache-name-string) gptel-llm-session-cache)
-            `((status . "success")
-              (message . ,(format "LLM cache '%s' cleared." cache-name-string))))
-        `((status . "error")
-          (message . ,(format "LLM cache '%s' not found." cache-name-string))))
-    (progn
-      (clrhash gptel-llm-session-cache)
-      `((status . "success")
-        (message . "All LLM caches cleared.")))))
-
-;; --- Context Injection ---
-
-(defun gptel-slim-inject-cache-names (&optional _info)
-  "Inject active LLM cache names into the gptel prompt buffer.
-Intended to be used in `gptel-prompt-transform-functions'.
-INFO is the request plist provided by gptel."
-  (let* ((cache-result (gptel-llm-cache-list-names))
-         (names-vector (alist-get 'names cache-result))
-         (names-list (and names-vector (append names-vector nil))))
-    (when names-list
-      (goto-char (point-max))
-      (insert "\n\n--- Available Caches ---\n")
-      (dolist (name names-list)
-        (insert (format "- %s\n" name))))))
-
-;; Register the injection function in gptel's prompt transformation hook
-(add-hook 'gptel-prompt-transform-functions #'gptel-slim-inject-cache-names)
-
-;; --- Tool Declarations ---
-
-(gptel-make-tool
- :name "llm_cache_set"
- :function #'gptel-llm-cache-set
- :description "Sets or updates an Elisp data object in the LLM's in-memory session cache. The LLM can define the name of the cache and store arbitrary Elisp data literals (lists, strings, numbers, hash tables). Use this for autonomous caching of relevant information. IMPORTANT: DO NOT provide executable code, only data literals (e.g., '(\"item1\" \"item2\"), \"a string\", 123, (make-hash-table :test 'equal))."
- :args (list '(:name "cache_name_string" :type string :description "The string name for the Elisp symbol to be used as a cache (e.g., \"my-relevant-tags\").")
-             '(:name "elisp_data_string" :type string :description "A string containing an Elisp data literal to store (e.g., '(\"tag1\" \"tag2\"), \"a summary string\", 123, (make-hash-table :test 'equal)).")))
-
-(gptel-make-tool
- :name "llm_cache_get"
- :function #'gptel-llm-cache-get
- :description "Retrieves the Elisp data object associated with a given name from the LLM's in-memory session cache. Returns the data as an Elisp string representation."
- :args (list '(:name "cache_name_string" :type string :description "The string name of the Elisp cache symbol to retrieve.")))
-
-(gptel-make-tool
- :name "llm_cache_clear"
- :function #'gptel-llm-cache-clear
- :description "Clears a specific Elisp data object from the LLM's in-memory session cache, or clears all caches if no name is provided."
- :args (list '(:name "cache_name_string" :type string :optional t :description "The string name of the Elisp cache symbol to clear (optional, clears all if omitted).")))
-
-(provide 'gptel-llm-cache)
-;;; gptel-llm-cache.el ends here
-#+end_src
-
-
 **  Feature 3: Send Node at Point
     Quero inserir uma nova opção no menu transient do gptel de nome
     'Send Node at Point' que irá enviar apenas o nó em que o usuário
@@ -586,6 +429,7 @@ INFO is the request plist provided by gptel."
     'investigate_code_tag' ou 'investigate_buffer_tag' ou as novas
     tools que consultam o =.llm-doc.json= permitindo uma assistência
     dentro do código mais rica e ao mesmo tempo magra.
+
 ** Feature 4: Original via Git
 :PROPERTIES:
 :GPTEL_TOPIC: git_state_tools

--- a/docs/ROADMAP.org
+++ b/docs/ROADMAP.org
@@ -185,11 +185,250 @@ A filosofia central permanece: *KISS, Suckless, sem RAG pesado, sem telemetria. 
 
 *** O Gerador inicial
 
+*Descritivo do workflow para o gerador inicial =M-x gptel-slim-init-doc=*  
+`gptel-slim-init-doc` será o comando para gerar o arquivo inicial `.llm-doc.json` na raiz do seu projeto. Ele é projetado para ser robusto, interativo e aproveitar as ferramentas existentes no Emacs e no sistema para coletar informações detalhadas do código, minimizando a carga inicial do LLM.
+
+**1. Como Chamar a Função**
+
+ Execute `M-x gptel-slim-init-doc`. A função tentará inferir o diretório raiz do projeto a partir do buffer atual (arquivo ou Dired).
+
+**2. Pré-requisitos Essenciais**
+
+Para uma execução bem-sucedida, o ambiente deve atender aos seguintes pontos:
+
+-   **Emacs 28+ com `gptel`:** O pacote `gptel` deve estar instalado, configurado e funcional.
+-   **Projeto Versionado por Git:** O diretório raiz do projeto *deve* ser um repositório Git para extração de metadados como `last_commit_hash` e `commit_timestamp`.
+-   **Identificação da Raiz do Projeto:** A função buscará a raiz na seguinte ordem de preferência: `project.el`, arquivo `.project`, diretório `.git/`, ou `default-directory`.
+-   **etags Instalado:** o etags deve estar no `PATH` para gerar o arquivo `TAGS`.
+-   **Opcional - LSP (Eglot/LSP-mode):** dependência para obter informações mais ricas (assinaturas, referências, tipos) através de um servidor LSP ativo para a linguagem do seu projeto.
+
+**3. Fluxo de Trabalho Simplificado**
+
+O processo de geração do `.llm-doc.json` deve seguir estas etapas:
+
+1.  **Verificação e Confirmação:**
+    -   Verifica a existência de um `.llm-doc.json` e solicita confirmação para sobrescrever, se necessário.
+    -   Confirma a raiz do projeto detectada com o usuário.
+
+2.  **Coleta de Metadados do Projeto:**
+    *   Extrai `project_name` (do nome do diretório), `last_commit_hash` e `commit_timestamp` (do Git).
+
+3.  **Identificação de Dependências Externas:**
+    *   Tenta identificar e listar dependências a partir de arquivos de manifesto comuns (ex: `package.json`, `requirements.txt`) na raiz do projeto.
+
+4.  **Geração/Atualização do Arquivo `TAGS`:**
+    *   Gera ou atualiza o arquivo `TAGS` para todo o projeto usando `ctags`, essencial para mapeamento de símbolos.
+
+5.  **Extração de Símbolos e Contexto do Código:**
+    *   Percorre os arquivos de código-fonte do projeto, ignorando diretórios de build/dependências.
+    *   **Prioridade 1 (LSP):** Utiliza o servidor LSP ativo para obter símbolos (funções, variáveis, classes), seus tipos, escopos, assinaturas e referências cruzadas.
+    *   **Prioridade 2 (Tree-sitter):** Se o LSP não estiver disponível, tenta usar o Tree-sitter para parsear o código e extrair informações.
+    *   **Prioridade 3 (`TAGS`):** Como fallback final, lê o arquivo `TAGS` para obter `tag_name`, `type` e `origin_file`, deixando os detalhes para o LLM.
+
+6.  **Geração de Sumários e Detalhes via LLM:**
+    *   Para cada tag extraída, a função lê o bloco de código correspondente.
+    *   Envia este snippet ao LLM (via `gptel-api-query`) com um prompt específico para gerar `summary`, `cross_references`, `signature`, `scope` e `data_type`.
+
+7.  **Construção e Salvamento do `.llm-doc.json`:**
+    *   Agrega todos os dados coletados e gerados pelo LLM em uma estrutura JSON.
+    *   Serializa a estrutura e salva como `.llm-doc.json` na raiz do projeto.
+    *   Exibe uma mensagem de sucesso e sugere adicionar o arquivo ao `.gitignore` ou commitá-lo, conforme a intenção do usuário.
+
+Este fluxo garante que o `gptel-slim-init-doc` seja um gerador abrangente, que aproveita ao máximo as ferramentas disponíveis para criar um `.llm-doc.json` inicial rico em contexto e preciso.o de Tags e Contexto (Estratégia de Fallback):**
+    -   Percorre os arquivos de código-fonte do projeto (ignorando diretórios comuns como `.git/`, `node_modules/`).
+    -   **Prioridade 1: LSP (Eglot/LSP-mode):** Tenta usar o servidor LSP ativo para obter símbolos, tipos, escopos, assinaturas e referências cruzadas (`textDocument/documentSymbol`, `textDocument/references`).
+    -   **Prioridade 2: Tree-sitter:** Se LSP não estiver disponível, utiliza Tree-sitter para parsear o código e extrair símbolos, tipos e assinaturas (referências cruzadas podem ser limitadas).
+    -   **Prioridade 3: Arquivo `TAGS`:** Como fallback final, lê o arquivo `TAGS` para obter `tag_name`, `type` e `origin_file`. Neste caso, campos como `summary`, `cross_references`, `signature`, `scope` e `data_type` serão inicialmente nulos e dependerão *inteiramente* da inferência do LLM.
+
+6.  **Geração de Sumários e Detalhes via LLM:**
+    -   Para cada tag extraída (com ou sem detalhes via LSP/Tree-sitter), o bloco de código correspondente é lido.
+    -   Este snippet é enviado ao LLM (via `gptel-api-query`) com um prompt específico para gerar: `summary`, `cross_references`, `signature`, `scope` e `data_type`.
+    -   A resposta do LLM é então usada para popular os campos correspondentes da tag.
+
+7.  **Construção e Salvamento do `.llm-doc.json`:**
+    -   Todos os dados coletados e gerados são agregados em uma estrutura de dados Elisp, mapeando o schema JSON definido.
+    -   Esta estrutura é serializada para JSON e salva como `.llm-doc.json` na raiz do projeto.
+    -   Uma mensagem de sucesso é exibida, com sugestões para gerenciar o arquivo (ex: adicionar ao `.gitignore` ou commitá-lo).
+
+Este workflow garante que o `gptel-slim-init-doc` seja um gerador abrangente, que maximiza o uso de ferramentas existentes para fornecer o contexto mais rico possível ao LLM, otimizando a precisão do `.llm-doc.json` gerado e minimizando o custo de tokens.
+
+
+
+
+
+
+
 *** O motor de consulta
 
 *** Hook de manutenção
 
-** Feature 2: Original via Git
+** Feature 2: Melhorias no cache
+   Hoje o llm_cache_* funciona muito bem mas há dois pontos de
+   melhoria latentes:
+   1. Criar uma função que printe o estado do cache um
+      gptel-slim-cache-dump. Ele poderia trazer todo o conteúdo do
+      cache para um buffer que poderia ser salvo e utilizado no dia
+      seguinte com um gptel-slim-cache-load;
+   2. A tool 'llm_cache_list_names' pode ser ajustada para que sua
+      description receba um apêndice contendo os nomes de cache já
+      salvos. Dessa forma a LLM não precisaria interagir com a tool
+      para ver os nomes salvos, o que traria economia de tokens de
+      saída e economizaria em uma rodada de interação da LLM.
+      Exemplo: LLM salva o cache "funcao_xpto". Em uma próxima
+      interação o nome "funcao_xpto" seria pritado ao final do texto
+      de description em uma seção "Caches salvos:".
+      Resumindo a tool 'llm_cache_list_names' não seria mais uma tool
+      a ser executada, pois seu description após o primeiro uso já
+      traria o enriquecimento de contexto necessário a utilização do
+      cache.
+      Talvez até poderia remover essa tool e fazer com que os nomes
+      dos caches definidos sejam printados no description de
+      llm_cache_get ou coisa semelhante. É um tema para refletir
+      posteriormente.
+      Se a estratégia for para o caminho de remover a tool
+      'llm_cache_list_names' em favor de colocar essa infor na
+      description de outra tool precisaremos de uma estratégia de
+      garbage-colector. No caso ao rodar 'llm_cache_clean' para
+      remover a definição de um cache o apendice do description
+      precisa ser higienizado junto, isso deve ser feito de forma
+      determinística, o único trabalho do LLM deve ser chamar
+      'llm_cache_clean' e a tool deve cuidar do restante.
+
+*** llm_cache_list_names
+
+
+/Proposta Técnica: Injeção Dinâmica de Contexto de Cache no =gptel=/
+
+/1. Visão Geral e Objetivo/
+
+Esta proposta descreve a implementação de um mecanismo para injetar
+dinamicamente os nomes dos caches ativos no prompt enviado à LLM
+através do pacote =gptel=. O objetivo principal é fornecer à LLM o
+conhecimento dos caches disponíveis de forma transparente (passiva),
+eliminando a necessidade de uma chamada de ferramenta (tool call)
+explícita para listar esses nomes. Isso resulta em economia de tokens,
+redução de latência (menos rodadas de interação) e uma arquitetura
+mais elegante e alinhada com os princípios KISS e Suckless. 
+
+/2. Arquitetura e Componentes/
+
+A solução baseia-se na utilização de hooks nativos do =gptel= para interceptar e modificar o prompt antes de seu envio.
+
+/Componentes Principais:/
+
+1.  /Estado do Cache (=gptel-llm-session-cache=):/ A estrutura de dados (hash table) existente que armazena os caches em memória.
+2.  /Função Extratora (=gptel-llm-cache-list-names=):/ A função Elisp existente que consulta o =gptel-llm-session-cache= e retorna a lista de nomes de caches ativos. Esta função deixará de ser exposta como uma tool para a LLM e passará a ser de uso estritamente interno.
+3.  /Função Injetora (=gptel-slim-inject-cache-names=):/ Uma nova função Elisp a ser implementada. Sua responsabilidade é coordenar a extração dos nomes e a formatação do texto a ser anexado ao prompt.
+4.  /Hook de Transformação (=gptel-prompt-transform-functions=):/ O hook nativo do =gptel= onde a Função Injetora será registrada. Este hook é acionado em um buffer temporário contendo o prompt final, permitindo modificações antes do envio.
+
+/3. Fluxo de Execução (Algoritmo)/
+
+O processo de injeção ocorre de forma determinística a cada nova requisição enviada pelo usuário à LLM.
+
+1.  /Interação do Usuário:/ O usuário submete um prompt no Emacs via =gptel=.
+2.  /Preparação do Prompt:/ O =gptel= inicia a construção do prompt em um buffer temporário.
+3.  /Acionamento do Hook:/ O =gptel= executa as funções registradas em =gptel-prompt-transform-functions=, incluindo a nossa Função Injetora (=gptel-slim-inject-cache-names=).
+4.  /Consulta ao Cache:/ A Função Injetora invoca a Função Extratora (=gptel-llm-cache-list-names=) para obter a lista atualizada de nomes de cache.
+5.  /Avaliação Condicional:/
+    *   /Caso A (Cache Vazio):/ Se a lista retornada for nula ou vazia, a Função Injetora encerra sua execução silenciosamente. Nenhuma alteração é feita no prompt.
+    *   /Caso B (Caches Existentes):/ Se a lista contiver elementos, a Função Injetora formata esses nomes em uma string descritiva (ex: "\n\n--- Caches Disponíveis ---\n- cache_a\n- cache_b").
+6.  /Injeção no Prompt:/ A string formatada é inserida no final do buffer temporário do prompt.
+7.  /Envio à LLM:/ O =gptel= envia o prompt final (agora enriquecido com o contexto dos caches) para a LLM.
+
+/4. Diagramas/
+
+/4.1. Diagrama de Fluxo (Comportamento)/
+
+Este diagrama ilustra a lógica condicional da Função Injetora.
+
+#+begin_src plantuml
+@startuml
+skinparam monochrome true
+skinparam defaultFontName "Cascadia Code"
+
+start
+:Usuário envia prompt via gptel;
+:gptel prepara buffer temporário do prompt;
+:gptel aciona **gptel-prompt-transform-functions**;
+:Executa **gptel-slim-inject-cache-names**;
+:**gptel-llm-cache-list-names** consulta o Hash Table;
+
+if (Existem caches ativos?) then (Sim)
+  :Formata lista de nomes em string;
+  :Insere string no final do buffer do prompt;
+else (Não)
+  :Não faz nada (retorna silenciosamente);
+endif
+
+:gptel envia prompt final para LLM;
+stop
+@enduml
+#+end_src
+
+/4.2. Diagrama de Blocos (Arquitetura e Interação)/
+
+Este diagrama detalha a interação entre os componentes do sistema.
+
+#+begin_src plantuml
+@startuml
+skinparam monochrome true
+skinparam packageStyle rectangle
+skinparam defaultFontName "Cascadia Code"
+
+actor "Usuário" as User
+boundary "Emacs / gptel UI" as UI
+control "gptel Core" as Core
+entity "gptel-llm-session-cache\n(Hash Table)" as Cache
+control "gptel-slim-inject-cache-names\n(Função Injetora)" as Injector
+control "gptel-llm-cache-list-names\n(Função Extratora)" as Extractor
+control "LLM" as LLM
+
+User -> UI : Envia Prompt
+UI -> Core : Inicia requisição
+
+box "Processamento do Prompt (Hook)"
+    Core -> Injector : Aciona via gptel-prompt-transform-functions
+    Injector -> Extractor : Solicita nomes dos caches
+    Extractor -> Cache : Lê chaves do Hash Table
+    Cache --> Extractor : Retorna lista de chaves (ou nil)
+    Extractor --> Injector : Retorna lista de nomes
+    
+    alt Caches existem
+        Injector -> Injector : Formata string
+        Injector -> Core : Modifica buffer do prompt (append)
+    else Caches não existem
+        Injector -> Core : Nenhuma ação (pass-through)
+    end
+end box
+
+Core -> LLM : Envia Prompt Enriquecido
+LLM --> Core : Retorna Resposta
+Core --> UI : Exibe Resposta
+
+@enduml
+#+end_src
+
+/5. Considerações sobre Ciclo de Vida (Garbage Collection)/
+
+A arquitetura proposta garante que a "coleta de lixo" seja
+inerentemente transparente. Como a Função Injetora consulta o estado
+do =gptel-llm-session-cache= em /tempo real/ a cada requisição,
+qualquer modificação prévia feita por ferramentas como
+=llm_cache_clear= ou =llm_cache_set= será imediatamente refletida na
+próxima injeção. Não há necessidade de mecanismos adicionais de
+sincronização ou limpeza de estado para a string injetada, pois ela é
+efêmera e gerada sob demanda. 
+
+**  Feature 3: Send Node at Point
+    Quero inserir uma nova opção no menu transient do gptel de nome
+    'Send Node at Point' que irá enviar apenas o nó em que o usuário
+    está trabalhando e automaticamente exigir um prompt na linha de
+    prompt. Também automaticamente enviaria o arquivo TAGS do projeto
+    e o nome do buffer para que o LLM possa escolher entre usar a tool
+    'investigate_code_tag' ou 'investigate_buffer_tag' ou as novas
+    tools que consultam o =.llm-doc.json= permitindo uma assistência
+    dentro do código mais rica e ao mesmo tempo magra.
+** Feature 4: Original via Git
 :PROPERTIES:
 :GPTEL_TOPIC: git_state_tools
 :END:
@@ -207,7 +446,7 @@ Ideia: Resolver o problema de 'edição em andamento' (onde o LLM só vê o cód
 
 ---
 
-** Feature 3: Injeção Automática de Diagnósticos (Flymake/Eglot)
+** Feature 5: Injeção Automática de Diagnósticos (Flymake/Eglot)
 :PROPERTIES:
 :GPTEL_TOPIC: flymake_injection
 :END:
@@ -226,7 +465,7 @@ Ideia: Enriquecer o contexto do LLM com diagnósticos em tempo real do Flymake/E
 
 ---
 
-** Feature 4: Orquestração, System Prompts e Gatilhos Condicionais
+** Feature 6: Orquestração, System Prompts e Gatilhos Condicionais
 :PROPERTIES:
 :GPTEL_TOPIC: orchestration
 :END:
@@ -245,3 +484,5 @@ sozinhas, mas sugiram sinergias quando outras tools estiverem ativas.
    - *Exemplo para =read_tag_source=:* "... Extrai o código fonte exato. *Sinergia:* Se precisar entender a arquitetura antes, use 'query_project_doc' (se ativa). Para salvar este código para depois, use 'llm_cache_set'."
 2. [ ] *Criação do System Prompt Mestre:*
    - Desenhar a persona do Agente Investigativo que prioriza a economia de tokens e a busca determinística (JSON > TAGS > Buffer > Diff).
+
+

--- a/docs/ROADMAP.org
+++ b/docs/ROADMAP.org
@@ -264,16 +264,17 @@ Este workflow garante que o `gptel-slim-init-doc` seja um gerador abrangente, qu
 
 ** Feature 2: Melhorias no cache
    Hoje o llm_cache_* funciona muito bem mas há dois pontos de
-   melhoria latentes:
-   1. Criar uma função que printe o estado do cache um
-      gptel-slim-cache-dump. Ele poderia trazer todo o conteúdo do
-      cache para um buffer que poderia ser salvo e utilizado no dia
-      seguinte com um gptel-slim-cache-load;
-   2. A tool 'llm_cache_list_names' pode ser ajustada para que sua
-      description receba um apêndice contendo os nomes de cache já
-      salvos. Dessa forma a LLM não precisaria interagir com a tool
-      para ver os nomes salvos, o que traria economia de tokens de
-      saída e economizaria em uma rodada de interação da LLM.
+   melhoria latentes [1/2]:
+   1. [ ] *dump/load state* :: Criar uma função que printe o estado do
+      cache um =gptel-slim-cache-dump=. Ele poderia trazer todo o
+      conteúdo do cache para um buffer que poderia ser salvo e
+      utilizado no dia seguinte com um =gptel-slim-cache-load=;
+   2. [X] *gestão dos nomes de cache* :: A tool =llm_cache_list_names=
+      pode ser ajustada para que sua description receba um apêndice
+      contendo os nomes de cache já salvos. Dessa forma a LLM não
+      precisaria interagir com a tool para ver os nomes salvos, o que
+      traria economia de tokens de saída e economizaria em uma rodada
+      de interação da LLM. 
       Exemplo: LLM salva o cache "funcao_xpto". Em uma próxima
       interação o nome "funcao_xpto" seria pritado ao final do texto
       de description em uma seção "Caches salvos:".
@@ -294,8 +295,7 @@ Este workflow garante que o `gptel-slim-init-doc` seja um gerador abrangente, qu
       determinística, o único trabalho do LLM deve ser chamar
       'llm_cache_clean' e a tool deve cuidar do restante.
 
-*** llm_cache_list_names
-
+*** Gestão dos nomes de cache
 
 /Proposta Técnica: Injeção Dinâmica de Contexto de Cache no =gptel=/
 
@@ -419,6 +419,164 @@ próxima injeção. Não há necessidade de mecanismos adicionais de
 sincronização ou limpeza de estado para a string injetada, pois ela é
 efêmera e gerada sob demanda. 
 
+**** Implementação
+
+Seguindo todas as boas práticas de programação elisp e todo o
+direcionamento técnico exposto acima precisamos criar a função
+=gptel-slim-inject-cache-names= e o hook para
+=gptel-prompt-transform-functions= 
+
+Para tanto segue código fonte das tools de cache:
+
+[[~/src/emacs-gptel-slim-tools/gptel-llm-cache.el]]
+
+
+Também segue o arquivo TAGS 
+
+[[~/.emacs.d/elpa/gptel-20260408.557/TAGS]]
+
+Que deve ser usado com a tool =investigate_code_tags= para gerar
+contexto e assim podermos executar essa implementação dentro das
+melhores práticas possíveis.
+
+
+
+
+#+begin_tool (investigate_code_tag :tags_file "~/.emacs.d/elpa/gptel-20260408.557/TAGS" :tag_name "gptel-prompt-transform-functions")
+(:name "investigate_code_tag" :args (:tags_file "~/.emacs.d/elpa/gptel-20260408.557/TAGS" :tag_name "gptel-prompt-transform-functions"))
+
+(defcustom gptel-prompt-transform-functions
+  '(gptel--transform-apply-preset gptel--transform-add-context)
+  "Handlers to augment or transform a query before sending it.
+
+This hook is called in a temporary buffer containing the text to
+be sent, with the cursor at the end of the prompt.  You can use
+it to modify the buffer or buffer-local variables as required.
+
+Since these functions modify the prompt construction buffer, the order
+in which they run is significant!  In particular, you may want to add
+your function before (the default) or after
+`gptel--transform-add-context', which adds gptel's context (other
+buffers, files etc) to this buffer.
+
+Example: A typical use case might be to search for occurrences of $(cmd)
+and replace it with the output of the shell command cmd, making it easy
+to send the output of shell commands to the LLM.
+
+Transform functions can be synchronous or asynchronous.
+
+Synchronous hook functions must accept zero or one argument: the INFO
+plist for the current request.
+
+Asynchronous hook functions must accept two arguments: a callback to
+call after the transformation is complete, and the INFO plist for the
+current request.
+
+Note that while this set of handlers can certainly be set with a global
+value to be applied to all queries in all buffers, it meant to be set
+locally for a specific buffer, or chat topic, or only the context of a
+certain task."
+  :type 'hook)
+
+
+#+end_tool
+#+begin_src elisp
+;;; gptel-llm-cache.el --- LLM-managed ephemeral session cache -*- lexical-binding: t; -*-
+
+(require 'gptel)
+
+(defvar gptel-llm-session-cache (make-hash-table :test 'eq)
+  "Hash table to store LLM-managed session cache data.
+Keys are symbols representing cache names, values are arbitrary Elisp data.
+This cache is ephemeral and cleared on Emacs restart.")
+
+(defun gptel-llm-cache-set (cache-name-string elisp-data-string)
+  "Sets or updates an Elisp data object in the LLM's in-memory session cache."
+  (let* ((cache-symbol (intern cache-name-string))
+         (data (read-from-string elisp-data-string)))
+    (puthash cache-symbol data gptel-llm-session-cache)
+    `((status . "success")
+      (cache_name . ,cache-name-string)
+      (data . ,(prin1-to-string data)))))
+
+(defun gptel-llm-cache-get (cache-name-string)
+  "Retrieves an Elisp data object from the LLM's in-memory session cache."
+  (let* ((cache-symbol (intern cache-name-string))
+         (data (gethash cache-symbol gptel-llm-session-cache)))
+    (if data
+        `((status . "success")
+          (cache_name . ,cache-name-string)
+          (data . ,(prin1-to-string data)))
+      `((status . "error")
+        (message . ,(format "LLM cache '%s' not found." cache-name-string))))))
+
+(defun gptel-llm-cache-list-names ()
+  "Lists the string names of all Elisp data objects currently stored.
+Used internally for context injection."
+  (let (names)
+    (maphash (lambda (key _value) (push (symbol-name key) names)) gptel-llm-session-cache)
+    `((status . "success")
+      (names . ,(vconcat (nreverse names))))))
+
+(defun gptel-llm-cache-clear (&optional cache-name-string)
+  "Clears a specific Elisp data object from the LLM's in-memory session cache."
+  (if cache-name-string
+      (if (gethash (intern cache-name-string) gptel-llm-session-cache)
+          (progn
+            (remhash (intern cache-name-string) gptel-llm-session-cache)
+            `((status . "success")
+              (message . ,(format "LLM cache '%s' cleared." cache-name-string))))
+        `((status . "error")
+          (message . ,(format "LLM cache '%s' not found." cache-name-string))))
+    (progn
+      (clrhash gptel-llm-session-cache)
+      `((status . "success")
+        (message . "All LLM caches cleared.")))))
+
+;; --- Context Injection ---
+
+(defun gptel-slim-inject-cache-names (&optional _info)
+  "Inject active LLM cache names into the gptel prompt buffer.
+Intended to be used in `gptel-prompt-transform-functions'.
+INFO is the request plist provided by gptel."
+  (let* ((cache-result (gptel-llm-cache-list-names))
+         (names-vector (alist-get 'names cache-result))
+         (names-list (and names-vector (append names-vector nil))))
+    (when names-list
+      (goto-char (point-max))
+      (insert "\n\n--- Available Caches ---\n")
+      (dolist (name names-list)
+        (insert (format "- %s\n" name))))))
+
+;; Register the injection function in gptel's prompt transformation hook
+(add-hook 'gptel-prompt-transform-functions #'gptel-slim-inject-cache-names)
+
+;; --- Tool Declarations ---
+
+(gptel-make-tool
+ :name "llm_cache_set"
+ :function #'gptel-llm-cache-set
+ :description "Sets or updates an Elisp data object in the LLM's in-memory session cache. The LLM can define the name of the cache and store arbitrary Elisp data literals (lists, strings, numbers, hash tables). Use this for autonomous caching of relevant information. IMPORTANT: DO NOT provide executable code, only data literals (e.g., '(\"item1\" \"item2\"), \"a string\", 123, (make-hash-table :test 'equal))."
+ :args (list '(:name "cache_name_string" :type string :description "The string name for the Elisp symbol to be used as a cache (e.g., \"my-relevant-tags\").")
+             '(:name "elisp_data_string" :type string :description "A string containing an Elisp data literal to store (e.g., '(\"tag1\" \"tag2\"), \"a summary string\", 123, (make-hash-table :test 'equal)).")))
+
+(gptel-make-tool
+ :name "llm_cache_get"
+ :function #'gptel-llm-cache-get
+ :description "Retrieves the Elisp data object associated with a given name from the LLM's in-memory session cache. Returns the data as an Elisp string representation."
+ :args (list '(:name "cache_name_string" :type string :description "The string name of the Elisp cache symbol to retrieve.")))
+
+(gptel-make-tool
+ :name "llm_cache_clear"
+ :function #'gptel-llm-cache-clear
+ :description "Clears a specific Elisp data object from the LLM's in-memory session cache, or clears all caches if no name is provided."
+ :args (list '(:name "cache_name_string" :type string :optional t :description "The string name of the Elisp cache symbol to clear (optional, clears all if omitted).")))
+
+(provide 'gptel-llm-cache)
+;;; gptel-llm-cache.el ends here
+#+end_src
+
+
 **  Feature 3: Send Node at Point
     Quero inserir uma nova opção no menu transient do gptel de nome
     'Send Node at Point' que irá enviar apenas o nó em que o usuário
@@ -486,3 +644,11 @@ sozinhas, mas sugiram sinergias quando outras tools estiverem ativas.
    - Desenhar a persona do Agente Investigativo que prioriza a economia de tokens e a busca determinística (JSON > TAGS > Buffer > Diff).
 
 
+** Melhoria da documentação
+   Hoje as tools ainda estão em um status simples. Sua arquitetura é
+   bastante fácil de entender por algum leigo ou novo usuário. Mas com
+   as melhorias propostas nesse documento sua complexidade de uso e
+   devida orquestração e também a manutenção inerente se tornarão mais
+   complexas. Preciso criar uma estratégia de documentação
+   consistente.
+   

--- a/gptel-llm-cache.el
+++ b/gptel-llm-cache.el
@@ -73,20 +73,20 @@ INFO is the request plist provided by gptel."
 (gptel-make-tool
  :name "llm_cache_set"
  :function #'gptel-llm-cache-set
- :description "Sets or updates an Elisp data object in the LLM's in-memory session cache. The LLM can define the name of the cache and store arbitrary Elisp data literals (lists, strings, numbers, hash tables). Use this for autonomous caching of relevant information. IMPORTANT: DO NOT provide executable code, only data literals (e.g., '(\"item1\" \"item2\"), \"a string\", 123, (make-hash-table :test 'equal))."
+ :description "The Scrapbook. Store/update Elisp data literal (list, string, number, hash) in memory cache. NO EXECUTABLE CODE. Synergy: Batch multiple calls. Updates Available Caches list."
  :args (list '(:name "cache_name_string" :type string :description "The string name for the Elisp symbol to be used as a cache (e.g., \"my-relevant-tags\").")
              '(:name "elisp_data_string" :type string :description "A string containing an Elisp data literal to store (e.g., '(\"tag1\" \"tag2\"), \"a summary string\", 123, (make-hash-table :test 'equal)).")))
 
 (gptel-make-tool
  :name "llm_cache_get"
  :function #'gptel-llm-cache-get
- :description "Retrieves the Elisp data object associated with a given name from the LLM's in-memory session cache. Returns the data as an Elisp string representation."
+ :description "Retrieve cached Elisp data string by name. Synergy: Check Available Caches prompt list before calling. Counterpart to llm_cache_set."
  :args (list '(:name "cache_name_string" :type string :description "The string name of the Elisp cache symbol to retrieve.")))
 
 (gptel-make-tool
  :name "llm_cache_clear"
  :function #'gptel-llm-cache-clear
- :description "Clears a specific Elisp data object from the LLM's in-memory session cache, or clears all caches if no name is provided."
+ :description "Clear specific Elisp data from memory cache, or all if unnamed."
  :args (list '(:name "cache_name_string" :type string :optional t :description "The string name of the Elisp cache symbol to clear (optional, clears all if omitted).")))
 
 (provide 'gptel-llm-cache)

--- a/gptel-llm-cache.el
+++ b/gptel-llm-cache.el
@@ -12,8 +12,6 @@ This cache is ephemeral and cleared on Emacs restart.")
   (let* ((cache-symbol (intern cache-name-string))
          (data (read-from-string elisp-data-string)))
     (puthash cache-symbol data gptel-llm-session-cache)
-    ;; CORREÇÃO: Como 'data' pode ser uma lista Elisp arbitrária, passá-la
-    ;; diretamente vai quebrar o `json-serialize`. Retornamos como string.
     `((status . "success")
       (cache_name . ,cache-name-string)
       (data . ,(prin1-to-string data)))))
@@ -23,7 +21,6 @@ This cache is ephemeral and cleared on Emacs restart.")
   (let* ((cache-symbol (intern cache-name-string))
          (data (gethash cache-symbol gptel-llm-session-cache)))
     (if data
-        ;; CORREÇÃO: Retorna a representação em string para evitar crash no JSON.
         `((status . "success")
           (cache_name . ,cache-name-string)
           (data . ,(prin1-to-string data)))
@@ -31,11 +28,10 @@ This cache is ephemeral and cleared on Emacs restart.")
         (message . ,(format "LLM cache '%s' not found." cache-name-string))))))
 
 (defun gptel-llm-cache-list-names ()
-  "Lists the string names of all Elisp data objects currently stored."
+  "Lists the string names of all Elisp data objects currently stored.
+Used internally for context injection."
   (let (names)
     (maphash (lambda (key _value) (push (symbol-name key) names)) gptel-llm-session-cache)
-    ;; CORREÇÃO: O Emacs json-serialize EXIGE vetores para arrays JSON.
-    ;; Uma lista causaria um erro `plistp` ou corrupção de dados.
     `((status . "success")
       (names . ,(vconcat (nreverse names))))))
 
@@ -54,6 +50,24 @@ This cache is ephemeral and cleared on Emacs restart.")
       `((status . "success")
         (message . "All LLM caches cleared.")))))
 
+;; --- Context Injection ---
+
+(defun gptel-slim-inject-cache-names (&optional _info)
+  "Inject active LLM cache names into the gptel prompt buffer.
+Intended to be used in `gptel-prompt-transform-functions'.
+INFO is the request plist provided by gptel."
+  (let* ((cache-result (gptel-llm-cache-list-names))
+         (names-vector (alist-get 'names cache-result))
+         (names-list (and names-vector (append names-vector nil))))
+    (when names-list
+      (goto-char (point-max))
+      (insert "\n\n--- Available Caches ---\n")
+      (dolist (name names-list)
+        (insert (format "- %s\n" name))))))
+
+;; Register the injection function in gptel's prompt transformation hook
+(add-hook 'gptel-prompt-transform-functions #'gptel-slim-inject-cache-names)
+
 ;; --- Tool Declarations ---
 
 (gptel-make-tool
@@ -70,16 +84,9 @@ This cache is ephemeral and cleared on Emacs restart.")
  :args (list '(:name "cache_name_string" :type string :description "The string name of the Elisp cache symbol to retrieve.")))
 
 (gptel-make-tool
- :name "llm_cache_list_names"
- :function #'gptel-llm-cache-list-names
- :description "Lists the string names of all Elisp data objects currently stored in the LLM's in-memory session cache."
- :args nil)
-
-(gptel-make-tool
  :name "llm_cache_clear"
  :function #'gptel-llm-cache-clear
  :description "Clears a specific Elisp data object from the LLM's in-memory session cache, or clears all caches if no name is provided."
- ;; CORREÇÃO: Removido `(or string null)`. Usamos `:type string` com `:optional t`.
  :args (list '(:name "cache_name_string" :type string :optional t :description "The string name of the Elisp cache symbol to clear (optional, clears all if omitted).")))
 
 (provide 'gptel-llm-cache)

--- a/gptel-thin-buffer.el
+++ b/gptel-thin-buffer.el
@@ -153,14 +153,14 @@ and returns the exact source code string with engine metadata."
 (gptel-make-tool
  :name "list_buffer_tags"
  :function #'gptel-thin-buffer--list-adapter
- :description "Lists tags (functions, classes, keys) from an active buffer using structural parsing. Works for C/C++, Elisp, YAML, Python, Ansible, etc."
+ :description "List tags (functions, classes, keys) in active buffer via structural parsing (C/C++, Elisp, YAML, etc.). Synergy: Precedes read_tag_source. For project-wide search, use investigate_code_tag."
  :args (list '(:name "buffer_name" :type string :description "Name of the open buffer to analyze"))
  :category "investigation")
 
 (gptel-make-tool
  :name "read_tag_source"
  :function #'gptel-thin-buffer--extract-adapter
- :description "Extracts the exact source code of a specified tag/function/key from a buffer using structural bounds."
+ :description "Extract exact tag source from active buffer via structural bounds. Synergy: Find tags via list_buffer_tags and cache via llm_cache_set. Batch multiple calls."
  :args (list '(:name "buffer_name" :type string :description "Name of the buffer")
              '(:name "tag_name" :type string :description "Name of the tag/key to extract"))
  :category "investigation")

--- a/gptel-thin-tags.el
+++ b/gptel-thin-tags.el
@@ -99,7 +99,7 @@ Returns the exact string content of the temporary context buffer."
 (gptel-make-tool
  :name "investigate_code_tag"
  :function #'gptel-thin-tags--investigate-adapter
- :description "Extract and analyze a specific code fragment (function/variable) from the source code using a TAGS file. Use this to investigate the implementation of a suspected root-cause without reading the whole file."
+ :description "Extract project-wide code fragment (function/variable) via TAGS file. Avoids reading full files. Synergy: Cache findings via llm_cache_set. Batch multiple calls."
  :args (list '(:name "tag_name" :type string :description "The name of the function or definition to investigate")
              '(:name "tags_file" :type string :description "Path to the TAGS file"))
  :category "investigation")


### PR DESCRIPTION
Modifica as descrições das ferramentas de cache e de investigação de
código (`llm_cache_*`, `list_buffer_tags`, `read_tag_source`,
`investigate_code_tag`) para torná-las mais concisas e incluir dicas
de sinergia. Isso orienta o LLM a combinar chamadas e utilizar o
cache de forma mais eficiente.

Fixes: #14 